### PR TITLE
Update to JavaScriptKit 0.9, add `Global` helpers

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,11 +3,11 @@
     "pins": [
       {
         "package": "JavaScriptKit",
-        "repositoryURL": "https://github.com/j-f1/forked-JavaScriptKit.git",
+        "repositoryURL": "https://github.com/swiftwasm/JavaScriptKit.git",
         "state": {
-          "branch": "4429d88",
-          "revision": "4429d8893f197df5651a0e628e0b78701f19fcf3",
-          "version": null
+          "branch": null,
+          "revision": "b7a02434c6e973c08c3fd5069105ef44dd82b891",
+          "version": "0.9.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -6,14 +6,24 @@ import PackageDescription
 let package = Package(
     name: "DOMKit",
     products: [
+        .executable(
+            name: "DOMKitDemo",
+            targets: ["DOMKitDemo"]),
         .library(
             name: "DOMKit",
             targets: ["DOMKit"]),
     ],
     dependencies: [
-        .package(name: "JavaScriptKit", url: "https://github.com/j-f1/forked-JavaScriptKit.git", .revision("4429d88")),
+        .package(
+            name: "JavaScriptKit",
+            url: "https://github.com/swiftwasm/JavaScriptKit.git",
+            .upToNextMinor(from: "0.9.0")),
     ],
     targets: [
+        .target(
+            name: "DOMKitDemo",
+            dependencies: ["DOMKit"]
+        ),
         .target(
             name: "DOMKit",
             dependencies: ["JavaScriptKit"]),

--- a/Sources/DOMKit/ECMAScript/ArrayBuffer.swift
+++ b/Sources/DOMKit/ECMAScript/ArrayBuffer.swift
@@ -29,7 +29,7 @@ public class ArrayBuffer: JSBridgedClass {
         self.init(unsafelyWrapping: Self.constructor.new( length))
     }
 
-    public static func isView(_ object: JSValueCodable) -> Bool {
-        return JSObject.global.ArrayBuffer.object!.isView!(object).fromJSValue()!
+    public static func isView(_ object: JSValueCompatible) -> Bool {
+        JSObject.global.ArrayBuffer.object!.isView!(object).fromJSValue()!
     }
 }

--- a/Sources/DOMKit/ECMAScript/Support.swift
+++ b/Sources/DOMKit/ECMAScript/Support.swift
@@ -4,17 +4,28 @@
 
 import JavaScriptKit
 
-public class Promise<Type>: JSBridgedClass {
+public class Global {
+    public let jsObject = JSObject.global
+    public let document: Document
 
-    public static var constructor: JSFunction { JSObject.global.Promise.function! }
-
-    public let jsObject: JSObject
-
-    public required init(unsafelyWrapping jsObject: JSObject) {
-
-        self.jsObject = jsObject
+    init() {
+         document = Document(unsafelyWrapping: jsObject.document.object!)
     }
 }
+
+public extension Document {
+    var body: HTMLElement {
+        .init(unsafelyWrapping: jsObject.body.object!)
+    }
+}
+
+public extension HTMLElement {
+    convenience init?(from element: Element) {
+        self.init(from: .object(element.jsObject))
+    }
+}
+
+public let global = Global()
 
 public class ReadableStream: JSBridgedClass {
 
@@ -32,7 +43,7 @@ public class ReadableStream: JSBridgedClass {
     }
 }
 
-@propertyWrapper public struct ClosureHandler<ArgumentType: JSValueCodable, ReturnType: JSValueCodable> {
+@propertyWrapper public struct ClosureHandler<ArgumentType: JSValueCompatible, ReturnType: JSValueCompatible> {
 
     let jsObject: JSObject
     let name: String
@@ -52,7 +63,7 @@ public class ReadableStream: JSBridgedClass {
     }
 }
 
-@propertyWrapper public struct OptionalClosureHandler<ArgumentType: JSValueCodable, ReturnType: JSValueCodable> {
+@propertyWrapper public struct OptionalClosureHandler<ArgumentType: JSValueCompatible, ReturnType: JSValueCompatible> {
 
     let jsObject: JSObject
     let name: String
@@ -79,7 +90,7 @@ public class ReadableStream: JSBridgedClass {
     }
 }
 
-@propertyWrapper public struct ReadWriteAttribute<Wrapped: JSValueCodable> {
+@propertyWrapper public struct ReadWriteAttribute<Wrapped: JSValueCompatible> {
 
     let jsObject: JSObject
     let name: String
@@ -99,7 +110,7 @@ public class ReadableStream: JSBridgedClass {
     }
 }
 
-@propertyWrapper public struct ReadonlyAttribute<Wrapped: JSValueConstructible> {
+@propertyWrapper public struct ReadonlyAttribute<Wrapped: ConstructibleFromJSValue> {
 
     let jsObject: JSObject
     let name: String
@@ -116,7 +127,7 @@ public class ReadableStream: JSBridgedClass {
     }
 }
 
-public class ValueIterableIterator<SequenceType: JSBridgedClass & Sequence>: IteratorProtocol where SequenceType.Element: JSValueConstructible {
+public class ValueIterableIterator<SequenceType: JSBridgedClass & Sequence>: IteratorProtocol where SequenceType.Element: ConstructibleFromJSValue {
 
     private var index: Int = 0
     private let sequence: SequenceType
@@ -142,7 +153,7 @@ public protocol KeyValueSequence: Sequence where Element == (String, Value) {
     associatedtype Value
 }
 
-public class PairIterableIterator<SequenceType: JSBridgedClass & KeyValueSequence>: IteratorProtocol where SequenceType.Value: JSValueConstructible {
+public class PairIterableIterator<SequenceType: JSBridgedClass & KeyValueSequence>: IteratorProtocol where SequenceType.Value: ConstructibleFromJSValue {
 
     private let iterator: JSObject
     private let sequence: SequenceType

--- a/Sources/DOMKit/ECMAScript/Support.swift
+++ b/Sources/DOMKit/ECMAScript/Support.swift
@@ -4,13 +4,8 @@
 
 import JavaScriptKit
 
-public class Global {
-    public let jsObject = JSObject.global
-    public let document: Document
-
-    init() {
-         document = Document(unsafelyWrapping: jsObject.document.object!)
-    }
+public extension Window {
+    public var document: Document { Document(unsafelyWrapping: jsObject.document.object!) }
 }
 
 public extension Document {
@@ -25,7 +20,7 @@ public extension HTMLElement {
     }
 }
 
-public let global = Global()
+public let globalThis = Window(from: JSObject.global.jsValue())!
 
 public class ReadableStream: JSBridgedClass {
 

--- a/Sources/DOMKit/WebIDL/Blob.swift
+++ b/Sources/DOMKit/WebIDL/Blob.swift
@@ -50,11 +50,11 @@ public class Blob: JSBridgedClass {
         return jsObject.stream!().fromJSValue()!
     }
 
-    public func text() -> Promise<String> {
+    public func text() -> JSPromise<String, JSError> {
         return jsObject.text!().fromJSValue()!
     }
 
-    public func arrayBuffer() -> Promise<ArrayBuffer> {
+    public func arrayBuffer() -> JSPromise<ArrayBuffer, JSError> {
         return jsObject.arrayBuffer!().fromJSValue()!
     }
 }

--- a/Sources/DOMKitDemo/main.swift
+++ b/Sources/DOMKitDemo/main.swift
@@ -1,0 +1,10 @@
+import JavaScriptKit
+import DOMKit
+
+let document = global.document
+
+let header = HTMLElement(from: document.createElement(localName: "h1"))!
+header.innerText = "Hello World!"
+_ = document.body.appendChild(node: header)
+
+console.log(data: "Hello, world!")

--- a/Tests/DOMKitTests/DOMKitTests.swift
+++ b/Tests/DOMKitTests/DOMKitTests.swift
@@ -4,7 +4,7 @@ import JavaScriptKit
 
 final class DOMKitTests: XCTestCase {
     func testExample() {
-        let document = DOMKit.Document(from: JSObject.global.document)!
+        let document = globalThis.document
         let button = document.createElement(localName: "button")
         button.textContent = "Hello, world"
         button.addEventListener(type: "click", callback: { event in


### PR DESCRIPTION
Updates JavaScriptKit dependency to upstream 0.9 instead of using a fork as previously. I've updated a few helpers to use non-deprecated names and also added `Global` type and `public let global = Global()` with a few extensions on DOM types which for some reason don't seem to be declared in WebIDL.

Additional `DOMKitDemo` target and product are set up for easy manual test.