### PR TITLE
Assert on `queriedButton` not `button` in the test

### DIFF
--- a/Tests/DOMKitTests/DOMKitTests.swift
+++ b/Tests/DOMKitTests/DOMKitTests.swift
@@ -6,12 +6,9 @@ final class DOMKitTests: XCTestCase {
         let document = globalThis.document
         let button = document.createElement(localName: "button")
         button.textContent = "Hello, world!"
-        button.addEventListener(type: "click") { event in
-            (event.target as? HTMLElement)?.textContent = "Clicked!"
-        }
         _ = document.querySelector(selectors: "body")?.appendChild(node: button)
 
         let queriedButton = document.querySelector(selectors: "body button")
-        XCTAssertEqual(button.textContent, "Hello, world!")
+        XCTAssertEqual(queriedButton?.textContent, "Hello, world!")
     }
 }


### PR DESCRIPTION
The current test was meaningless as we didn't assert on the text content of `queriedButton`.

I've also removed `addEventListener` because it doesn't actually work. The `button` instance is already deallocated by the time that test has finished, so the closure passed to `addEventListener` is released too. We need to find a way to run async tests like this, and I have a few thoughts, but this still needs to be explored.