### PR TITLE
Pass `GITHUB_TOKEN` in `test.yml`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,3 +20,5 @@ jobs:
           brew install swiftwasm/tap/carton
 
           carton test --environment defaultBrowser
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The lack of this token causes sporadic issues with API rate limiting on GitHub Actions hosts.